### PR TITLE
Issue #2 - Xur Method Error

### DIFF
--- a/lib/destiny_rb/vendors.rb
+++ b/lib/destiny_rb/vendors.rb
@@ -8,7 +8,7 @@ module Destiny
 
       if raw
         raw_data
-      elsif raw_data.empty?
+      elsif raw_data.empty? || raw_data.nil?
         return nil
       else
         vendor_hash = raw_data['data']['vendorHash']


### PR DESCRIPTION
fixes #2  case where raw_data is nil
This happens when Xur isnt at the tower and bungie doesnt return empty tags. Instead they just omit the tag entirely:

```
{
ErrorCode: 1627
ThrottleSeconds: 0
ErrorStatus: "DestinyVendorNotFound"
Message: "The Vendor you requested was not found."
MessageData: {}
}
```
